### PR TITLE
refactor existing pipeline to use more effective targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,10 @@
 .Ruserdata
 
 .remake/*
+
+1_fetch/out/nwis_01427207_data.csv
+1_fetch/out/nwis_01432160_data.csv
+1_fetch/out/nwis_01435000_data.csv
+1_fetch/out/nwis_01436690_data.csv
+1_fetch/out/nwis_01466500_data.csv
+1_fetch/out/nwis_01477050_data.csv

--- a/.gitignore
+++ b/.gitignore
@@ -5,9 +5,4 @@
 
 .remake/*
 
-1_fetch/out/nwis_01427207_data.csv
-1_fetch/out/nwis_01432160_data.csv
-1_fetch/out/nwis_01435000_data.csv
-1_fetch/out/nwis_01436690_data.csv
-1_fetch/out/nwis_01466500_data.csv
-1_fetch/out/nwis_01477050_data.csv
+1_fetch/out/*.csv

--- a/1_fetch/src/get_nwis_data.R
+++ b/1_fetch/src/get_nwis_data.R
@@ -6,8 +6,7 @@ download_nwis_data <- function(site_nums = c("01427207", "01432160", "01435000",
   # replace tempdir() with "1_fetch/out" or another desired folder if you want to retain the download
   download_files <- file.path(dl_dir, paste0('nwis_', site_nums, '_data.csv'))
   
-  data_out <- data.frame(agency_cd = c(), site_no = c(), dateTime = c(), 
-                         X_00010_00000 = c(), X_00010_00000_cd = c(), tz_cd = c())
+
   # loop through files to download 
   for (download_file in download_files){
     download_nwis_site_data(download_file, parameterCd = parameterCd)

--- a/1_fetch/src/get_nwis_data.R
+++ b/1_fetch/src/get_nwis_data.R
@@ -1,24 +1,25 @@
 
-download_nwis_data <- function(site_nums = c("01427207", "01432160", "01435000", "01436690", "01466500", "01477050"), parameterCd = '00010'){
+download_nwis_data <- function(site_nums = c("01427207", "01432160", "01435000", "01436690", "01466500", "01477050"), parameterCd = '00010', dl_dir = '1_fetch/out'){
   
   # create the file names that are needed for download_nwis_site_data
   # tempdir() creates a temporary directory that is wiped out when you start a new R session; 
   # replace tempdir() with "1_fetch/out" or another desired folder if you want to retain the download
-  download_files <- file.path(tempdir(), paste0('nwis_', site_nums, '_data.csv'))
+  download_files <- file.path(dl_dir, paste0('nwis_', site_nums, '_data.csv'))
   
   data_out <- data.frame(agency_cd = c(), site_no = c(), dateTime = c(), 
                          X_00010_00000 = c(), X_00010_00000_cd = c(), tz_cd = c())
   # loop through files to download 
   for (download_file in download_files){
     download_nwis_site_data(download_file, parameterCd = parameterCd)
-    # read the downloaded data and append it to the existing data.frame
-    these_data <- read_csv(download_file, col_types = 'ccTdcc')
-    data_out <- rbind(data_out, these_data)
+    
   }
-  return(data_out)
+  return(download_files)
+  
 }
 
-nwis_site_info <- function(fileout, site_data){
+nwis_site_info <- function(fileout, nwis_data_path = '2_process/out/nwis_data.csv'){
+  
+  site_data <- read_csv(nwis_data_path)
   site_no <- unique(site_data$site_no)
   site_info <- dataRetrieval::readNWISsite(site_no)
   write_csv(site_info, fileout)
@@ -45,4 +46,10 @@ download_nwis_site_data <- function(filepath, parameterCd, startDate="2014-05-01
   write_csv(data_out, path = filepath)
   return(filepath)
 }
+
+
+
+
+
+
 

--- a/2_process/src/process_and_style.R
+++ b/2_process/src/process_and_style.R
@@ -1,5 +1,8 @@
 combine_nwis_data <- function(download_files){
 
+  data_out <- data.frame(agency_cd = c(), site_no = c(), dateTime = c(), 
+                         X_00010_00000 = c(), X_00010_00000_cd = c(), tz_cd = c())
+  
   for (download_file in download_files){
 
     # read the downloaded data and append it to the existing data.frame

--- a/2_process/src/process_and_style.R
+++ b/2_process/src/process_and_style.R
@@ -1,19 +1,31 @@
-process_data <- function(nwis_data){
-  nwis_data_clean <- rename(nwis_data, water_temperature = X_00010_00000) %>% 
-    select(-agency_cd, -X_00010_00000_cd, tz_cd)
+combine_nwis_data <- function(download_files){
+
+  for (download_file in download_files){
+
+    # read the downloaded data and append it to the existing data.frame
+    these_data <- read_csv(download_file, col_types = 'ccTdcc')
+    data_out <- rbind(data_out, these_data)
+  }
   
-  return(nwis_data_clean)
+  write_csv(data_out, '2_process/out/nwis_data.csv')
+  
 }
 
-annotate_data <- function(site_data_clean, site_filename){
+
+process_and_style <- function(nwis_data_path = '2_process/out/nwis_data.csv', site_filename = '1_fetch/out/site_info.csv'){
+  
+  nwis_data <- read_csv(nwis_data_path)
   site_info <- read_csv(site_filename)
-  annotated_data <- left_join(site_data_clean, site_info, by = "site_no") %>% 
-    select(station_name = station_nm, site_no, dateTime, water_temperature, latitude = dec_lat_va, longitude = dec_long_va)
   
-  return(annotated_data)
+  nwis_data_clean <- nwis_data %>%
+    rename(water_temperature = X_00010_00000) %>% 
+    select(-agency_cd, -X_00010_00000_cd, tz_cd) %>%
+    left_join(site_info, by = "site_no") %>% 
+    select(station_name = station_nm, site_no, dateTime, water_temperature, latitude = dec_lat_va, longitude = dec_long_va)
+    
+  return(nwis_data_clean)
+  
 }
 
 
-style_data <- function(site_data_annotated){
-  mutate(site_data_annotated, station_name = as.factor(station_name))
-}
+

--- a/remake.yml
+++ b/remake.yml
@@ -15,20 +15,17 @@ targets:
   all:
     depends: 3_visualize/out/figure_1.png
 
-  site_data:
-    command: download_nwis_data()
+  download_files:
+    command: download_nwis_data(dl_dir = '1_fetch/out')
+    
+  2_process/out/nwis_data.csv:
+    command: combine_nwis_data(download_files)
   
   1_fetch/out/site_info.csv:
-    command: nwis_site_info(target_name, site_data)
-
-  site_data_clean:
-    command: process_data(site_data)
-
-  site_data_annotated:
-    command: annotate_data(site_data_clean, site_filename = '1_fetch/out/site_info.csv')
+    command: nwis_site_info(target_name, nwis_data_path = '2_process/out/nwis_data.csv')
 
   site_data_styled:
-    command: style_data(site_data_annotated)	
+    command: process_and_style(nwis_data_path = '2_process/out/nwis_data.csv', site_filename = '1_fetch/out/site_info.csv')
 
   3_visualize/out/figure_1.png:
     command: plot_nwis_timeseries(target_name, site_data_styled)


### PR DESCRIPTION
Achieves two goals:
- isolates data download from all processing 
- combines data processing steps in single function

Because errors may occur when downloading data, I isolated this step from all processing by saving retrieved data in '1_fetch/out' and returning the associated file paths to a target 'download_files'. This target is then used by a new function 'combine_nwis_data' that creates the compiled data frame and saves it as '2_process/out/nwis_data.csv'.

The compiled data file is subsequently used as input to targets '1_fetch/out/site_info.csv' and 'site_data_styled'. The latter is produced via a simplified processing and styling function that combines previous functions 'process_data', 'annotate_data', and 'style_data', which seemed appropriate because there were no other direct dependencies of the intermediate objects that warranted a unique target. The new function produces the cleaned data frame for plotting.